### PR TITLE
Small behavioral changes to radius in geom_circle

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,8 +31,9 @@ Suggests:
     igraph,
     ggmap,
     spelling,
-    rmarkdown
+    rmarkdown,
+    markdown
 VignetteBuilder: knitr
 Encoding: UTF-8
 Language: en-US
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1.9001

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,9 +31,8 @@ Suggests:
     igraph,
     ggmap,
     spelling,
-    rmarkdown,
-    markdown
+    rmarkdown
 VignetteBuilder: knitr
 Encoding: UTF-8
 Language: en-US
-RoxygenNote: 7.1.1.9001
+RoxygenNote: 7.1.0

--- a/R/geom-circle.r
+++ b/R/geom-circle.r
@@ -19,7 +19,7 @@ scaleRadius <- function(data) {
 GeomCircle <- ggplot2::ggproto("GeomCircle", ggplot2::Geom,
   required_aes = c("x", "y", "radius", "radius.fixed"),
   default_aes = ggplot2::aes(
-    colour = "grey30", fill=NA, alpha=NA, linewidth=1, linetype="solid"),
+    colour = "grey30", fill=NA, alpha=NA, linewidth=1, linetype="solid", radius=0.5 ),
 
   draw_key = function (data, params, size)
   {
@@ -96,9 +96,11 @@ GeomCircle <- ggplot2::ggproto("GeomCircle", ggplot2::Geom,
 #' ggplot(df, aes(x=x, y=y)) + geom_point(cex=4) + geom_circle(radius=1, col="red", radius.fixed=T) + xlim(-3,3) + ylim(-3,3)
 #' ggplot(df, aes(x=x, y=y)) + geom_point(cex=4) + geom_circle(radius=0.55, col="red", radius.fixed=F) + xlim(-3,3) + ylim(-3,3)
 
+# radius = 0.05, 
+
 geom_circle <- function(mapping = NULL, data = NULL, stat = "identity",
                         position = "identity", na.rm = FALSE, show.legend = NA,
-                        inherit.aes = TRUE, radius = 0.05, radius.fixed = F, ...) {
+                        inherit.aes = TRUE, radius.fixed = F, ...) {
   
   print(":::")
   print(radius.fixed)
@@ -107,7 +109,7 @@ geom_circle <- function(mapping = NULL, data = NULL, stat = "identity",
   ggplot2::layer(
     geom = GeomCircle, mapping = mapping,  data = data, stat = stat,
     position = position, show.legend = show.legend, inherit.aes = inherit.aes,
-    params = list(na.rm = na.rm, radius = radius, radius.fixed=radius.fixed, ...)
+    params = list(na.rm = na.rm, radius.fixed=radius.fixed, ...) # radius = radius, 
   )
 }
 

--- a/R/geom-circle.r
+++ b/R/geom-circle.r
@@ -38,9 +38,9 @@ GeomCircle <- ggplot2::ggproto("GeomCircle", ggplot2::Geom,
 
 
   draw_panel = function(data, panel_scales, coord,  radius.fixed, na.rm = TRUE) {
-    print("---")
+    #print("---")
     print(radius.fixed)
-    print("---")
+    #print("---")
     
     if(radius.fixed) {
       dx <- abs(panel_scales$x.range[2] - panel_scales$x.range[1])
@@ -76,6 +76,7 @@ GeomCircle <- ggplot2::ggproto("GeomCircle", ggplot2::Geom,
 #' It is not explored for any more general use, so use with caution!
 #' @inheritParams ggplot2::geom_point
 #' @param radius numeric value giving the radius of the circle to be drawn (0-1 normalized scale)
+#' @param radius.fixed Make the size of the radius fixed to grid coordinates instead of xlim and ylim (T/F)
 #' @export
 #' @examples
 #' # circles are drawn centered at x and y
@@ -92,9 +93,9 @@ geom_circle <- function(mapping = NULL, data = NULL, stat = "identity",
                         position = "identity", na.rm = FALSE, show.legend = NA,
                         inherit.aes = TRUE, radius = 0.05, radius.fixed = F, ...) {
   
-  print(":::")
+  #print(":::")
   print(radius.fixed)
-  print(":::")
+  #print(":::")
   
   ggplot2::layer(
     geom = GeomCircle, mapping = mapping,  data = data, stat = stat,

--- a/R/geom-circle.r
+++ b/R/geom-circle.r
@@ -38,9 +38,9 @@ GeomCircle <- ggplot2::ggproto("GeomCircle", ggplot2::Geom,
 
 
   draw_panel = function(data, panel_scales, coord,  radius.fixed, na.rm = TRUE) {
-    #print("---")
-    #print(radius.fixed)
-    #print("---")
+    print("---")
+    print(radius.fixed)
+    print("---")
     
     if(radius.fixed) {
       dx <- abs(panel_scales$x.range[2] - panel_scales$x.range[1])
@@ -48,11 +48,16 @@ GeomCircle <- ggplot2::ggproto("GeomCircle", ggplot2::Geom,
       d <- min(dx, dy)
       
       coords <- coord$transform(data, panel_scales)
+      print(coords)
+      
       coords$radius <- coords$radius / d # scale proportional to screen
       #coords <- scaleRadius(coords) # scaling to reset to [0, 1] unnecessary
+      print(coords)
     } else {
       coords <- coord$transform(data, panel_scales)
+      print(coords)
       coords <- scaleRadius(coords)
+      print(coords)
     }
 
     grid::circleGrob(
@@ -93,9 +98,9 @@ geom_circle <- function(mapping = NULL, data = NULL, stat = "identity",
                         position = "identity", na.rm = FALSE, show.legend = NA,
                         inherit.aes = TRUE, radius = 0.05, radius.fixed = F, ...) {
   
-  #print(":::")
-  #print(radius.fixed)
-  #print(":::")
+  print(":::")
+  print(radius.fixed)
+  print(":::")
   
   ggplot2::layer(
     geom = GeomCircle, mapping = mapping,  data = data, stat = stat,

--- a/R/geom-circle.r
+++ b/R/geom-circle.r
@@ -47,6 +47,8 @@ GeomCircle <- ggplot2::ggproto("GeomCircle", ggplot2::Geom,
       dy <- abs(panel_scales$y.range[2] - panel_scales$y.range[1])
       d <- min(dx, dy)
       
+      print(paste0("D = min("dx,,", ",dy,") = ", d))
+      
       coords <- coord$transform(data, panel_scales)
       print(coords)
       

--- a/R/geom-circle.r
+++ b/R/geom-circle.r
@@ -81,10 +81,15 @@ GeomCircle <- ggplot2::ggproto("GeomCircle", ggplot2::Geom,
 #' ggplot(mpg, aes(displ, hwy)) + geom_circle(radius=0.1) + geom_point()
 #' ggplot(mpg, aes(displ, hwy)) + geom_circle(linetype=2, radius=0.05, alpha=0.5)
 #' ggplot(mpg, aes(displ, hwy)) + geom_circle(aes(linetype=factor(cyl)), radius=0.05, alpha=0.5)
+#' df = data.frame(x = 0, y = 0)
+#' ggplot(df, aes(x=x, y=y)) + geom_point(cex=4) + geom_circle(radius=1, col="red", radius.fixed=T) + xlim(-3,3) + ylim(-3,3)
+#' ggplot(df, aes(x=x, y=y)) + geom_point(cex=4) + geom_circle(radius=0.55, col="red", radius.fixed=F) + xlim(-3,3) + ylim(-3,3)
+
+
 
 geom_circle <- function(mapping = NULL, data = NULL, stat = "identity",
                               position = "identity", na.rm = FALSE, show.legend = NA,
-                              inherit.aes = TRUE, radius = 0.05, ...) {
+                              inherit.aes = TRUE, radius = 0.05, radius.fixed=F, ...) {
   ggplot2::layer(
     geom = GeomCircle, mapping = mapping,  data = data, stat = stat,
     position = position, show.legend = show.legend, inherit.aes = inherit.aes,

--- a/R/geom-circle.r
+++ b/R/geom-circle.r
@@ -37,7 +37,7 @@ GeomCircle <- ggplot2::ggproto("GeomCircle", ggplot2::Geom,
   },
 
 
-  draw_panel = function(data, panel_scales, coord, radius.fixed, na.rm = TRUE) {
+  draw_panel = function(data, panel_scales, coord,  radius.fixed, na.rm = TRUE) {
     print("---")
     print(radius.fixed)
     print("---")
@@ -76,7 +76,6 @@ GeomCircle <- ggplot2::ggproto("GeomCircle", ggplot2::Geom,
 #' It is not explored for any more general use, so use with caution!
 #' @inheritParams ggplot2::geom_point
 #' @param radius numeric value giving the radius of the circle to be drawn (0-1 normalized scale)
-#' @param radius.fixed whether or not to fixed the radius to grid coordinates (T/F)
 #' @export
 #' @examples
 #' # circles are drawn centered at x and y
@@ -89,19 +88,19 @@ GeomCircle <- ggplot2::ggproto("GeomCircle", ggplot2::Geom,
 #' ggplot(df, aes(x=x, y=y)) + geom_point(cex=4) + geom_circle(radius=1, col="red", radius.fixed=T) + xlim(-3,3) + ylim(-3,3)
 #' ggplot(df, aes(x=x, y=y)) + geom_point(cex=4) + geom_circle(radius=0.55, col="red", radius.fixed=F) + xlim(-3,3) + ylim(-3,3)
 
-
-
 geom_circle <- function(mapping = NULL, data = NULL, stat = "identity",
-                              position = "identity", na.rm = FALSE, show.legend = NA,
-                              inherit.aes = TRUE, radius = 0.05, radius.fixed=F, ...) {
+                        position = "identity", na.rm = FALSE, show.legend = NA,
+                        inherit.aes = TRUE, radius = 0.05, radius.fixed = F, ...) {
+  
   print(":::")
   print(radius.fixed)
   print(":::")
-
+  
   ggplot2::layer(
     geom = GeomCircle, mapping = mapping,  data = data, stat = stat,
     position = position, show.legend = show.legend, inherit.aes = inherit.aes,
     params = list(na.rm = na.rm, radius = radius, radius.fixed=radius.fixed, ...)
   )
 }
+
 

--- a/R/geom-circle.r
+++ b/R/geom-circle.r
@@ -37,7 +37,7 @@ GeomCircle <- ggplot2::ggproto("GeomCircle", ggplot2::Geom,
   },
 
 
-  draw_panel = function(data, panel_scales, coord,  na.rm = TRUE) {
+  draw_panel = function(data, panel_scales, coord, radius.fixed, na.rm = TRUE) {
     if(radius.fixed) {
       dx <- abs(panel_scales$x.range[2] - panel_scales$x.range[1])
       dy <- abs(panel_scales$y.range[2] - panel_scales$y.range[1])

--- a/R/geom-circle.r
+++ b/R/geom-circle.r
@@ -38,6 +38,10 @@ GeomCircle <- ggplot2::ggproto("GeomCircle", ggplot2::Geom,
 
 
   draw_panel = function(data, panel_scales, coord, radius.fixed, na.rm = TRUE) {
+    print("---")
+    print(radius.fixed)
+    print("---")
+    
     if(radius.fixed) {
       dx <- abs(panel_scales$x.range[2] - panel_scales$x.range[1])
       dy <- abs(panel_scales$y.range[2] - panel_scales$y.range[1])
@@ -90,6 +94,10 @@ GeomCircle <- ggplot2::ggproto("GeomCircle", ggplot2::Geom,
 geom_circle <- function(mapping = NULL, data = NULL, stat = "identity",
                               position = "identity", na.rm = FALSE, show.legend = NA,
                               inherit.aes = TRUE, radius = 0.05, radius.fixed=F, ...) {
+  print(":::")
+  print(radius.fixed)
+  print(":::")
+
   ggplot2::layer(
     geom = GeomCircle, mapping = mapping,  data = data, stat = stat,
     position = position, show.legend = show.legend, inherit.aes = inherit.aes,

--- a/R/geom-circle.r
+++ b/R/geom-circle.r
@@ -38,28 +38,19 @@ GeomCircle <- ggplot2::ggproto("GeomCircle", ggplot2::Geom,
 
 
   draw_panel = function(data, panel_scales, coord,  radius.fixed, na.rm = TRUE) {
-    print("---")
-    print(radius.fixed)
-    print("---")
     
     if(radius.fixed) {
       dx <- abs(panel_scales$x.range[2] - panel_scales$x.range[1])
       dy <- abs(panel_scales$y.range[2] - panel_scales$y.range[1])
       d <- min(dx, dy)
       
-      print(paste0("D = min(", dx, ", ", dy, ") = ", d))
-      
       coords <- coord$transform(data, panel_scales)
-      print(coords)
       
-      coords$radius <- coords$radius / d # scale proportional to screen
+      coords$radius <- coords$radius / d # scale proportional to grid
       #coords <- scaleRadius(coords) # scaling to reset to [0, 1] unnecessary
-      print(coords)
     } else {
       coords <- coord$transform(data, panel_scales)
-      print(coords)
       coords <- scaleRadius(coords)
-      print(coords)
     }
 
     grid::circleGrob(
@@ -101,10 +92,6 @@ GeomCircle <- ggplot2::ggproto("GeomCircle", ggplot2::Geom,
 geom_circle <- function(mapping = NULL, data = NULL, stat = "identity",
                         position = "identity", na.rm = FALSE, show.legend = NA,
                         inherit.aes = TRUE, radius.fixed = F, ...) {
-  
-  print(":::")
-  print(radius.fixed)
-  print(":::")
   
   ggplot2::layer(
     geom = GeomCircle, mapping = mapping,  data = data, stat = stat,

--- a/R/geom-circle.r
+++ b/R/geom-circle.r
@@ -87,8 +87,6 @@ GeomCircle <- ggplot2::ggproto("GeomCircle", ggplot2::Geom,
 #' ggplot(df, aes(x=x, y=y)) + geom_point(cex=4) + geom_circle(radius=1, col="red", radius.fixed=T) + xlim(-3,3) + ylim(-3,3)
 #' ggplot(df, aes(x=x, y=y)) + geom_point(cex=4) + geom_circle(radius=0.55, col="red", radius.fixed=F) + xlim(-3,3) + ylim(-3,3)
 
-# radius = 0.05, 
-
 geom_circle <- function(mapping = NULL, data = NULL, stat = "identity",
                         position = "identity", na.rm = FALSE, show.legend = NA,
                         inherit.aes = TRUE, radius.fixed = F, ...) {
@@ -96,7 +94,7 @@ geom_circle <- function(mapping = NULL, data = NULL, stat = "identity",
   ggplot2::layer(
     geom = GeomCircle, mapping = mapping,  data = data, stat = stat,
     position = position, show.legend = show.legend, inherit.aes = inherit.aes,
-    params = list(na.rm = na.rm, radius.fixed=radius.fixed, ...) # radius = radius, 
+    params = list(na.rm = na.rm, radius.fixed=radius.fixed, ...)
   )
 }
 

--- a/R/geom-circle.r
+++ b/R/geom-circle.r
@@ -39,7 +39,7 @@ GeomCircle <- ggplot2::ggproto("GeomCircle", ggplot2::Geom,
 
   draw_panel = function(data, panel_scales, coord,  radius.fixed, na.rm = TRUE) {
     #print("---")
-    print(radius.fixed)
+    #print(radius.fixed)
     #print("---")
     
     if(radius.fixed) {
@@ -94,7 +94,7 @@ geom_circle <- function(mapping = NULL, data = NULL, stat = "identity",
                         inherit.aes = TRUE, radius = 0.05, radius.fixed = F, ...) {
   
   #print(":::")
-  print(radius.fixed)
+  #print(radius.fixed)
   #print(":::")
   
   ggplot2::layer(

--- a/R/geom-circle.r
+++ b/R/geom-circle.r
@@ -47,7 +47,7 @@ GeomCircle <- ggplot2::ggproto("GeomCircle", ggplot2::Geom,
       dy <- abs(panel_scales$y.range[2] - panel_scales$y.range[1])
       d <- min(dx, dy)
       
-      print(paste0("D = min("dx,,", ",dy,") = ", d))
+      print(paste0("D = min(", dx, ", ", dy, ") = ", d))
       
       coords <- coord$transform(data, panel_scales)
       print(coords)

--- a/man/geom_circle.Rd
+++ b/man/geom_circle.Rd
@@ -19,7 +19,6 @@ geom_circle(
   na.rm = FALSE,
   show.legend = NA,
   inherit.aes = TRUE,
-  radius = 0.05,
   radius.fixed = F,
   ...
 )
@@ -65,14 +64,14 @@ rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 
-\item{radius}{numeric value giving the radius of the circle to be drawn (0-1 normalized scale)}
-
 \item{radius.fixed}{Make the size of the radius fixed to grid coordinates instead of xlim and ylim (T/F)}
 
 \item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
 \code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
+
+\item{radius}{numeric value giving the radius of the circle to be drawn (0-1 normalized scale)}
 }
 \description{
 Circles are drawn with a specified radius centered at (x, y).

--- a/man/geom_circle.Rd
+++ b/man/geom_circle.Rd
@@ -20,6 +20,7 @@ geom_circle(
   show.legend = NA,
   inherit.aes = TRUE,
   radius = 0.05,
+  radius.fixed = F,
   ...
 )
 }
@@ -66,6 +67,8 @@ the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 
 \item{radius}{numeric value giving the radius of the circle to be drawn (0-1 normalized scale)}
 
+\item{radius.fixed}{Make the size of the radius fixed to grid coordinates instead of xlim and ylim (T/F)}
+
 \item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
 \code{colour = "red"} or \code{size = 3}. They may also be parameters
@@ -83,5 +86,8 @@ data(mpg)
 ggplot(mpg, aes(displ, hwy)) + geom_circle(radius=0.1) + geom_point()
 ggplot(mpg, aes(displ, hwy)) + geom_circle(linetype=2, radius=0.05, alpha=0.5)
 ggplot(mpg, aes(displ, hwy)) + geom_circle(aes(linetype=factor(cyl)), radius=0.05, alpha=0.5)
+df = data.frame(x = 0, y = 0)
+ggplot(df, aes(x=x, y=y)) + geom_point(cex=4) + geom_circle(radius=1, col="red", radius.fixed=T) + xlim(-3,3) + ylim(-3,3)
+ggplot(df, aes(x=x, y=y)) + geom_point(cex=4) + geom_circle(radius=0.55, col="red", radius.fixed=F) + xlim(-3,3) + ylim(-3,3)
 }
 \keyword{datasets}


### PR DESCRIPTION
Dear geomnet team,

This pull request:
 - adds the 'radius.fixed' argument to geom_circle. The default behaviour of this argument is left unchanged. Once enabled, the circles are not scaled to xlim/ylim but to the actual grid (https://github.com/sctyner/geomnet/issues/33).
 - puts the 'radius' argument into AES since it an aesthetic.

Could you please have careful look at this since I am not an expert with the gg stack.

kind regards,

Youri

